### PR TITLE
New algorithm: Hidden sets

### DIFF
--- a/server/sudoku-sos-solver/src/puzzle.rs
+++ b/server/sudoku-sos-solver/src/puzzle.rs
@@ -14,7 +14,7 @@ pub struct Puzzle {
     pub empty_count: u32,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub enum Step {
     Elimination {
         value: Vec<u8>,
@@ -31,7 +31,7 @@ pub enum Step {
     },
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub enum SolveAlgorithm {
     SoleCandidate,
     UniqueRow,

--- a/server/sudoku-sos-solver/src/puzzle/cell.rs
+++ b/server/sudoku-sos-solver/src/puzzle/cell.rs
@@ -19,10 +19,11 @@ pub struct Elimination {
     pub algorithm: EliminationAlgorithm,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub enum EliminationAlgorithm {
     FilledCell,
     NakedSet,
+    HiddenSet,
 }
 
 impl Cell {

--- a/sudoku-client/src/utils/index.ts
+++ b/sudoku-client/src/utils/index.ts
@@ -10,6 +10,8 @@ export const formatAlgorithmString = (algorithm: string): string => {
             return "Unique Column";
         case "NakedSet":
             return "Naked Set";
+        case "HiddenSet":
+            return "Hidden Set";
         default:
             return algorithm;
     }


### PR DESCRIPTION
**Hidden Sets** are now identified using the existing Naked Set algorithm, since the inverse of a Naked Set _is_ a Hidden Set. If the eliminators of our Naked Set (the group of cells that form the Naked Set and ultimately _eliminate_ the other candidates) consist of the majority of the unfilled cells within the given house, the function will convert the Naked Set to a Hidden Set by:
- flipping the eliminators to be the same cells as the victims and
- changing the algorithm enum to "HiddenSet"

By flipping the eliminators, we imply that the cause of these candidates being eliminated are the remaining candidates within the very same cells.

In the future, we might need a way to highlight what house the Hidden Set takes part in, as there can be some confusion between a Box and a Row/Column.